### PR TITLE
Feature expose git tag as env variable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>git-tag-message</artifactId>
-  <version>1.4-SNAPSHOT</version>
+  <version>1.4.3-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Git Tag Message Plugin</name>

--- a/src/main/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageAction.java
+++ b/src/main/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageAction.java
@@ -8,17 +8,23 @@ import hudson.model.EnvironmentContributingAction;
 public class GitTagMessageAction implements EnvironmentContributingAction {
 
     /** The name of the environment variable this plugin exports. */
-    static final String ENV_VAR_NAME = "GIT_TAG_MESSAGE";
+    static final String ENV_VAR_NAME_MESSAGE = "GIT_TAG_MESSAGE";
+    static final String ENV_VAR_NAME_TAG = "GIT_TAG_NAME";
 
     private final String tagMessage;
+    private final String tagName;
 
-    public GitTagMessageAction(String tagMessage) {
+    public GitTagMessageAction(String tagName, String tagMessage) {
         this.tagMessage = tagMessage;
+        this.tagName = tagName;
     }
 
     public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
         if (tagMessage != null) {
-            env.put(ENV_VAR_NAME, tagMessage);
+            env.put(ENV_VAR_NAME_MESSAGE, tagMessage);
+        }
+        if (tagName != null){
+            env.put(ENV_VAR_NAME_TAG, tagName);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtension.java
+++ b/src/main/java/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtension.java
@@ -67,7 +67,7 @@ public class GitTagMessageExtension extends GitSCMExtension {
                 listener.getLogger().println(Messages.NoTagMessageFound(tagName));
                 LOGGER.finest(String.format("No tag message could be determined for git tag '%s'.", tagName));
             } else {
-                build.addAction(new GitTagMessageAction(tagMessage));
+                build.addAction(new GitTagMessageAction(tagName,tagMessage));
                 listener.getLogger().println(Messages.ExportingTagMessage(ENV_VAR_NAME, tagName));
                 LOGGER.finest(String.format("Exporting tag message '%s' from tag '%s'.", tagMessage, tagName));
             }

--- a/src/main/resources/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtension/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/gittagmessage/GitTagMessageExtension/help.html
@@ -1,8 +1,10 @@
 <div>
-  If the revision checked out has a git tag associated with it, and a message
-  was specified when creating the tag, then that message will be exported during
-  the build as the <strong><tt>GIT_TAG_MESSAGE</tt></strong> environment
-  variable.<br/>If no tag message was specified, the commit message will be used.
+  If the revision checked out has a git tag associated with it the tag will be 
+  exported during the build as <strong><tt>GIT_TAG_NAME</tt></strong>.
+  If a message was specified when creating the tag, then that message will be 
+  exported during the build as the <strong><tt>GIT_TAG_MESSAGE</tt></strong> 
+  environment variable.
+  <br/>If no tag message was specified, the commit message will be used.
   <p/>
   If the revision has more than one tag associated with it, only the most recent
   tag will be taken into account, <strong>unless</strong> the refspec contains

--- a/src/main/resources/org/jenkinsci/plugins/gittagmessage/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/gittagmessage/Messages.properties
@@ -1,4 +1,5 @@
-DisplayName=Export git tag message as environment variable
+DisplayName=Export git tag and message as environment variable
 NoTagFound=Tag information could not be determined for this revision; no git tag message will be exported
 NoTagMessageFound=No tag message could be determined for git tag ''{0}''
 ExportingTagMessage=Exporting {0} from tag ''{1}''
+ExportingTagName=Exporting git-tag {0} to variable ''{1}''


### PR DESCRIPTION
[JENKINS-28705]
Exposes the actual git-tag as a env. variable,
Something we really needed in our build systems.
Updated internal documentation for the plugin.
