### PR TITLE
Modernize plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,21 +4,19 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.17</version>
-    <relativePath />
+    <version>3.56</version>
   </parent>
   <artifactId>git-tag-message</artifactId>
   <version>1.6.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <properties>
-    <jenkins.version>1.651.1</jenkins.version>
-    <java.level>7</java.level>
-    <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <name>Git Tag Message Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Git+Tag+Message+Plugin</url>
+  <url>https://wiki.jenkins.io/display/JENKINS/Git+Tag+Message+Plugin</url>
   <description>Exports the message for a git tag as an environment variable during a build.</description>
 
   <developers>
@@ -40,7 +38,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>git</artifactId>
-      <version>2.5.0</version>
+      <version>3.9.0</version>
     </dependency>
 
     <!-- Pipeline basics required for testing -->
@@ -56,21 +54,18 @@
       <version>2.9</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- Pipeline steps used in testing -->
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-basic-steps</artifactId>
-      <version>2.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-durable-task-step</artifactId>
-      <version>2.4</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>junit</artifactId>
+        <version>1.3</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>
@@ -84,7 +79,6 @@
     </plugins>
   </build>
 
-  <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>

--- a/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/gittagmessage/AbstractGitTagMessageExtensionTest.java
@@ -1,8 +1,10 @@
 package org.jenkinsci.plugins.gittagmessage;
 
 import hudson.model.Job;
+import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.plugins.git.util.BuildData;
+import jenkins.model.ParameterizedJobMixIn;
 import org.jenkinsci.plugins.gitclient.Git;
 import org.jenkinsci.plugins.gitclient.GitClient;
 import org.junit.Before;
@@ -15,7 +17,7 @@ import java.io.IOException;
 
 import static org.junit.Assert.assertNotNull;
 
-public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R>, R extends Run<J, R>> {
+public abstract class AbstractGitTagMessageExtensionTest<J extends Job<J, R> & ParameterizedJobMixIn.ParameterizedJob, R extends Run<J, R> & Queue.Executable> {
 
     @Rule public final JenkinsRule jenkins = new JenkinsRule();
 


### PR DESCRIPTION
With the upgrade to the latest parent pom, e.g. more meta-info and less jar files are packaged in the .hpi, more checks are performed in the build.

Because Java 7 is end-of-life since a while, upgrading to Java 8 and one of the first Jenkins LTS versions that requires it.

Upgrading git dependency to be more up-to-date and that less other dependency versions have to be declared to comply with the maven-enforcer plugin.